### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For channels where there is no EPG, this can also be utilised to provide a chann
 
 # Media Player Configuration
 
-There are two methods of configuration, via the Homa Assistant Integrations UI dialogue or via YAML. You cannot use both for the same Sky Q box, please use one or the other. Previous YAML configurations are not migrated to the UI method, please continue to use YAML, or delete YAML, reboot and add via UI.
+There are two methods of configuration, via the Home Assistant Integrations UI dialogue or via YAML. You cannot use both for the same Sky Q box, please use one or the other. Previous YAML configurations are not migrated to the UI method, please continue to use YAML, or delete YAML, reboot and add via UI.
 
 ## Integrations UI (from v2.2.0)
 


### PR DESCRIPTION
Very (very) minor change to Readme to fix a typo (Homa Assistant -> Home Assistant)