### PR TITLE
Log "not available" at info level

### DIFF
--- a/custom_components/skyq/media_player.py
+++ b/custom_components/skyq/media_player.py
@@ -574,7 +574,7 @@ class SkyQDevice(MediaPlayerEntity):
                 and self._available
             ):
                 self._available = False
-                _LOGGER.error(f"E0010M - Device is not available: {self.name}")
+                _LOGGER.info(f"I0010M - Device is not available: {self.name}")
 
         else:
             if not self._available:

--- a/custom_components/skyq/media_player.py
+++ b/custom_components/skyq/media_player.py
@@ -574,7 +574,7 @@ class SkyQDevice(MediaPlayerEntity):
                 and self._available
             ):
                 self._available = False
-                _LOGGER.info(f"I0010M - Device is not available: {self.name}")
+                _LOGGER.warning(f"W0030M - Device is not available: {self.name}")
 
         else:
             if not self._available:


### PR DESCRIPTION
Because SkyQ go normally off-line during firmware update or night stand-by, logging unavailable status as error is not correct because is expected behavior. I think it should be an `info`, at maximum a `warning`.
Just my opinion and not a real issue, so just discard this PR if you disagree.
Thanks for the integration. 