### PR TITLE
Fix device_info name

### DIFF
--- a/custom_components/skyq/entity.py
+++ b/custom_components/skyq/entity.py
@@ -1,20 +1,25 @@
 """Entity representing a Sky Device."""
 
-from homeassistant.helpers.entity import Entity
-
 from .const import DOMAIN
 
 
-class SkyQEntity(Entity):
+class SkyQEntity:
     """Representation of a SkyQ Device."""
 
+    def __init__(self, remote, config):
+        """Initialise the SkyQEntity."""
+        self._remote = remote
+        self._config = config
+        self._unique_id = config.unique_id
+        self._deviceInfo = None
+
     @property
-    def device_info(self):
+    def skyq_device_info(self):
         """Entity device information."""
         return (
             {
                 "identifiers": {(DOMAIN, self._deviceInfo.serialNumber)},
-                "name": self.name,
+                "name": self._config.name,
                 "manufacturer": self._deviceInfo.manufacturer,
                 "model": self._deviceInfo.hardwareModel,
                 "sw_version": f"{self._deviceInfo.ASVersion}:{self._deviceInfo.versionNumber}",
@@ -22,3 +27,14 @@ class SkyQEntity(Entity):
             if self._deviceInfo
             else None
         )
+
+    async def _async_get_device_info(self, hass):
+        """Query the device for device info."""
+        if self._deviceInfo:
+            return
+        self._deviceInfo = await hass.async_add_executor_job(self._remote.getDeviceInformation)
+        if self._deviceInfo:
+            if not self._unique_id:
+                self._unique_id = self._deviceInfo.epgCountryCode + "".join(
+                    e for e in self._deviceInfo.serialNumber.casefold() if e.isalnum()
+                )

--- a/custom_components/skyq/entity.py
+++ b/custom_components/skyq/entity.py
@@ -28,11 +28,11 @@ class SkyQEntity:
             else None
         )
 
-    async def _async_get_device_info(self):
+    async def _async_get_device_info(self, hass):
         """Query the device for device info."""
         if self._deviceInfo:
             return
-        self._deviceInfo = await self.hass.async_add_executor_job(self._remote.getDeviceInformation)
+        self._deviceInfo = await hass.async_add_executor_job(self._remote.getDeviceInformation)
         if self._deviceInfo:
             if not self._unique_id:
                 self._unique_id = self._deviceInfo.epgCountryCode + "".join(

--- a/custom_components/skyq/entity.py
+++ b/custom_components/skyq/entity.py
@@ -28,11 +28,11 @@ class SkyQEntity:
             else None
         )
 
-    async def _async_get_device_info(self, hass):
+    async def _async_get_device_info(self):
         """Query the device for device info."""
         if self._deviceInfo:
             return
-        self._deviceInfo = await hass.async_add_executor_job(self._remote.getDeviceInformation)
+        self._deviceInfo = await self.hass.async_add_executor_job(self._remote.getDeviceInformation)
         if self._deviceInfo:
             if not self._unique_id:
                 self._unique_id = self._deviceInfo.epgCountryCode + "".join(

--- a/custom_components/skyq/media_player.py
+++ b/custom_components/skyq/media_player.py
@@ -526,7 +526,7 @@ class SkyQDevice(SkyQEntity, MediaPlayerEntity):
             self._config.overrideCountry,
             self._config.test_channel,
         )
-        await self._async_get_device_info()
+        await self._async_get_device_info(self.hass)
         if self._deviceInfo:
             if not self._channel_list and len(self._config.channel_sources) > 0:
                 channelData = await self.hass.async_add_executor_job(self._remote.getChannelList)

--- a/custom_components/skyq/media_player.py
+++ b/custom_components/skyq/media_player.py
@@ -526,7 +526,7 @@ class SkyQDevice(SkyQEntity, MediaPlayerEntity):
             self._config.overrideCountry,
             self._config.test_channel,
         )
-        await self._async_get_device_info(self.hass)
+        await self._async_get_device_info()
         if self._deviceInfo:
             if not self._channel_list and len(self._config.channel_sources) > 0:
                 channelData = await self.hass.async_add_executor_job(self._remote.getChannelList)

--- a/custom_components/skyq/sensor.py
+++ b/custom_components/skyq/sensor.py
@@ -4,12 +4,17 @@ from datetime import timedelta
 
 from custom_components.skyq.entity import SkyQEntity
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import (CONF_NAME, DATA_GIGABYTES,
-                                 ENTITY_CATEGORY_DIAGNOSTIC)
+from homeassistant.const import CONF_NAME, DATA_GIGABYTES, ENTITY_CATEGORY_DIAGNOSTIC
 
 from .classes.config import Config
-from .const import (CONST_SKYQ_STORAGE_MAX, CONST_SKYQ_STORAGE_PERCENT,
-                    CONST_SKYQ_STORAGE_USED, DOMAIN, SKYQ_ICONS, SKYQREMOTE)
+from .const import (
+    CONST_SKYQ_STORAGE_MAX,
+    CONST_SKYQ_STORAGE_PERCENT,
+    CONST_SKYQ_STORAGE_USED,
+    DOMAIN,
+    SKYQ_ICONS,
+    SKYQREMOTE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,7 +90,7 @@ class SkyQUsedStorage(SkyQEntity, SensorEntity):
 
     async def async_update(self):
         """Get the latest data and update device state."""
-        await self._async_get_device_info()
+        await self._async_get_device_info(self.hass)
 
         resp = await self.hass.async_add_executor_job(self._remote.getQuota)
         if not resp:

--- a/custom_components/skyq/sensor.py
+++ b/custom_components/skyq/sensor.py
@@ -38,11 +38,14 @@ class SkyQUsedStorage(SkyQEntity, SensorEntity):
 
     def __init__(self, remote, config):
         """Initialize the used storage sensor."""
-        self._remote = remote
-        self._config = config
-        self._deviceInfo = None
+        super().__init__(remote, config)
         self._quotaInfo = None
         self._available = True
+
+    @property
+    def device_info(self):
+        """Entity device information."""
+        return self.skyq_device_info
 
     @property
     def unit_of_measurement(self):
@@ -56,8 +59,8 @@ class SkyQUsedStorage(SkyQEntity, SensorEntity):
 
     @property
     def unique_id(self):
-        """Get the name of the devices."""
-        return f"{self._config.unique_id}_used"
+        """Get the unique id of the devices."""
+        return f"{self._unique_id}_used" if self._unique_id else None
 
     @property
     def icon(self):
@@ -87,8 +90,7 @@ class SkyQUsedStorage(SkyQEntity, SensorEntity):
 
     async def async_update(self):
         """Get the latest data and update device state."""
-        if not self._deviceInfo:
-            await self._async_getDeviceInfo()
+        await self._async_get_device_info(self.hass)
 
         resp = await self.hass.async_add_executor_job(self._remote.getQuota)
         if not resp:
@@ -97,9 +99,6 @@ class SkyQUsedStorage(SkyQEntity, SensorEntity):
 
         self._powerStatus_on_handling()
         self._quotaInfo = resp
-
-    async def _async_getDeviceInfo(self):
-        self._deviceInfo = await self.hass.async_add_executor_job(self._remote.getDeviceInformation)
 
     def _powerStatus_off_handling(self):
         if self._available:

--- a/custom_components/skyq/sensor.py
+++ b/custom_components/skyq/sensor.py
@@ -4,17 +4,12 @@ from datetime import timedelta
 
 from custom_components.skyq.entity import SkyQEntity
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import CONF_NAME, DATA_GIGABYTES, ENTITY_CATEGORY_DIAGNOSTIC
+from homeassistant.const import (CONF_NAME, DATA_GIGABYTES,
+                                 ENTITY_CATEGORY_DIAGNOSTIC)
 
 from .classes.config import Config
-from .const import (
-    CONST_SKYQ_STORAGE_MAX,
-    CONST_SKYQ_STORAGE_PERCENT,
-    CONST_SKYQ_STORAGE_USED,
-    DOMAIN,
-    SKYQ_ICONS,
-    SKYQREMOTE,
-)
+from .const import (CONST_SKYQ_STORAGE_MAX, CONST_SKYQ_STORAGE_PERCENT,
+                    CONST_SKYQ_STORAGE_USED, DOMAIN, SKYQ_ICONS, SKYQREMOTE)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,7 +85,7 @@ class SkyQUsedStorage(SkyQEntity, SensorEntity):
 
     async def async_update(self):
         """Get the latest data and update device state."""
-        await self._async_get_device_info(self.hass)
+        await self._async_get_device_info()
 
         resp = await self.hass.async_add_executor_job(self._remote.getQuota)
         if not resp:


### PR DESCRIPTION
There is a little bug introduced with the new disk usage sensor that could cause the name of the device not properly set. Device could assume the name of the sensor (suffixed with "Used Storage") in case that the sensor is initialized before the `media_player` entity.
Because it seems logic to me to move some common variable inside the common class `SkyQEntity` that are used there to determinate device information, I moved initialization there, hoping that I correctly understand the means of this class.