### PR TITLE
fix: refresh entry host on SSDP rediscovery (DHCP drift)

### DIFF
--- a/custom_components/skyq/config_flow.py
+++ b/custom_components/skyq/config_flow.py
@@ -182,7 +182,7 @@ class SkyqConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 device_info.countryCode
                 + "".join(e for e in device_info.serialNumber.casefold() if e.isalnum())
             )
-            self._abort_if_unique_id_configured()
+            self._abort_if_unique_id_configured(updates={CONF_HOST: host})
 
     async def _async_validate_input(self, host, reconfigure=False):
         errors = {}


### PR DESCRIPTION
Closes #195 (and the long-standing symptom reported in #139, #178).

## Summary
- One-line change: pass `updates={CONF_HOST: host}` to `_abort_if_unique_id_configured()` in `SkyqConfigFlow._async_setuniqueid()`.
- When SSDP rediscovers a box at a new IP, HA now refreshes the existing entry's host and reloads it instead of dropping the new flow.
- The unique_id (`countryCode + casefolded(serialNumber)`) is stable across IP changes, so this is safe.

## Why
On networks that don't reliably honour DHCP reservations, Sky Mini boxes regularly get new IPs. With the current code, the entry's `CONF_HOST` stays stale, `SkyQRemote(host, ...)` fails on next setup, and the user has to reconfigure manually. SSDP rediscovery already runs — it just wasn't being used to refresh the host.

## Test plan
- [x] DHCP-drift recovery confirmed in my own deployment (3 Sky Mini boxes, IPs reassigned by router → entries auto-refresh on next SSDP announcement).
- [x] User-flow duplicate-host abort still works (preceding `_async_abort_entries_match` is unchanged).
- [x] Reconfigure flow unchanged (`reconfigure=True` still skips the unique_id branch).