### PR TITLE
Fix crash on live-record detection when recordings unavailable, plus two robustness fixes

### DIFF
--- a/custom_components/skyq/media_player.py
+++ b/custom_components/skyq/media_player.py
@@ -382,6 +382,7 @@ class SkyQDevice(SkyQEntity, MediaPlayerEntity):
         if not self._channel_list:
             self._channel_list = await self._async_get_channel_list()
 
+        error_state = False
         if self._config.device_info:
             error_state = await self._async_update_state()
         if error_state:
@@ -623,6 +624,10 @@ class SkyQDevice(SkyQEntity, MediaPlayerEntity):
         recordings = await self.hass.async_add_executor_job(
             self._remote.get_recordings, "RECORDING"
         )
+        if not recordings:
+            # get_recordings can transiently return None (box powering up/down or
+            # not answering); skip live-record detection this cycle rather than raise.
+            return
         for recording in recordings.recordings:
             if current_programme.programmeuuid == recording.programmeuuid:
                 self._entity_attr.skyq_media_type = SKYQ_LIVEREC

--- a/custom_components/skyq/utils.py
+++ b/custom_components/skyq/utils.py
@@ -207,7 +207,7 @@ async def async_get_device_info(hass, remote, unique_id):
 def host_valid(host):
     """Return True if hostname or IP address is valid."""
     try:
-        return ipaddress.ip_address(host).version == (4 or 6)
+        return ipaddress.ip_address(host).version in (4, 6)
     except ValueError:
         disallowed = re.compile(r"[^a-zA-Z\d\-]")
         return all(x and not disallowed.search(x) for x in host.split("."))


### PR DESCRIPTION
Three small, self-contained fixes, all around the "box unreachable / transiently empty response" theme.

### 1. `media_player.py` — `AttributeError` on live-record detection
`get_recordings("RECORDING")` can transiently return `None` (box powering up/down or not answering), and `_async_get_live_media` dereferenced `recordings.recordings` unguarded, raising `'NoneType' object has no attribute 'recordings'` (logged as `X0010`):

```
File ".../media_player.py", line 626, in _async_get_live_media
    for recording in recordings.recordings:
AttributeError: 'NoneType' object has no attribute 'recordings'
```

Added a `None` guard that skips live-record detection for that cycle, matching the existing pattern already used in `sensor.py` (`if not recordings:`) and in `_async_get_recording` (`if recording:`).

### 2. `media_player.py` — `UnboundLocalError` in `async_update`
`error_state` is only assigned inside `if self._config.device_info:`, but read unconditionally immediately after. When the box is unreachable at startup (device_info never obtained), `error_state` is unbound and every poll raises `UnboundLocalError`. Initialised `error_state = False`.

### 3. `utils.py` — `host_valid` IPv6 check
`.version == (4 or 6)` always evaluates to `.version == 4`, so a valid IPv6 gateway address was rejected. Changed to `.version in (4, 6)`.

All three are minimal and match the surrounding style; no behaviour change on the happy path.